### PR TITLE
Troca de serviço de email

### DIFF
--- a/src/BoraRachar.Domain.Service/Concretes/Amizades/AmizadeService.cs
+++ b/src/BoraRachar.Domain.Service/Concretes/Amizades/AmizadeService.cs
@@ -20,14 +20,14 @@ public partial class AmizadeService: BaseService, IAmizadeService
     private readonly IBaseRepository<Convite> _repositoryConvite;
     private readonly IBaseRepository<Grupos> _repositoryGrupo;
     private readonly IBaseRepository<Entity.Grupos.ParticipantesGrupo> _repositoryParticipantesGrupo;
-    private readonly IEmailService _emailService;
+    private readonly INovoEmailService _emailService;
     private readonly UserManager<User> _userManager;
     
     public AmizadeService(
         ILogger<AmizadeService> logger,
         IMapper mapper,
         IConfiguration config,
-        IEmailService emailService,
+        INovoEmailService emailService,
         IBaseRepository<Amizade> repository,
         IBaseRepository<Convite> repositoryConvite,
         IBaseRepository<Entity.Grupos.ParticipantesGrupo> repositoryParticipantesGrupo,

--- a/src/BoraRachar.Domain.Service/Concretes/Convites/ConviteService.cs
+++ b/src/BoraRachar.Domain.Service/Concretes/Convites/ConviteService.cs
@@ -14,14 +14,14 @@ public partial class ConviteService: BaseService, IConviteService
     private readonly IConfiguration _config;
     private readonly IMapper _mapper;
     private readonly IBaseRepository<Convite> _repository;
-    private readonly IEmailService _emailService;
+    private readonly INovoEmailService _emailService;
 
 
     public ConviteService(
         IMapper mapper,
         IBaseRepository<Convite> repository,
         IConfiguration config,
-        IEmailService emailService,
+        INovoEmailService emailService,
         ILogger<ConviteService> logger) : base(logger)
     {
         _repository = repository;

--- a/src/BoraRachar.Domain.Service/Concretes/Users/UserService.cs
+++ b/src/BoraRachar.Domain.Service/Concretes/Users/UserService.cs
@@ -17,7 +17,7 @@ public partial class UserService : BaseService, IUserService
     private readonly IBaseRepository<UserEntity> _repository;
     private readonly IBaseRepository<VerifyUser> _repositoryVerifyUser;
     private readonly UserManager<User> _userManager;
-    private readonly IEmailService _emailService;
+    private readonly INovoEmailService _emailService;
 
     public UserService(ILogger<UserService> logger,
         IMapper mapper,
@@ -25,7 +25,7 @@ public partial class UserService : BaseService, IUserService
         IBaseRepository<VerifyUser> repositoryVerifyUser,
         UserManager<User> userManager,
         IConfiguration config,
-        IEmailService emailService) : base(logger)
+        INovoEmailService emailService) : base(logger)
     {
         _mapper = mapper;
         _repository = repository;


### PR DESCRIPTION
Agora os serviços dependentes utilizam o novo serviço de email, implementando com mailkit e feito para integrar com o Gmail.